### PR TITLE
Añadido salto de linea al pedir entero

### DIFF
--- a/src/main/java/com/restaurante/utilidades.java
+++ b/src/main/java/com/restaurante/utilidades.java
@@ -12,8 +12,8 @@ public class utilidades {
 
     public static int PideEntero(String txt) {
         System.out.println(txt);
-        return tcl.nextInt();
+        int res = tcl.nextInt();
+        tcl.nextLine();
+        return res;
     }
-
-
 }


### PR DESCRIPTION
Se añade el cambio de salto de  linea al añadir un entero para evitar que el scanner se quede pillado y de esta manera el usuario pueda introducir los datos